### PR TITLE
Optimize individual codec instantiation

### DIFF
--- a/headers/codecfactory.h
+++ b/headers/codecfactory.h
@@ -30,44 +30,44 @@ private:
   CodecMap scodecmap;
 };
 
-std::shared_ptr<IntegerCODEC> fastbinarypacking8_codec();
-std::shared_ptr<IntegerCODEC> fastbinarypacking16_codec();
-std::shared_ptr<IntegerCODEC> fastbinarypacking32_codec();
-std::shared_ptr<IntegerCODEC> BP32_codec();
-std::shared_ptr<IntegerCODEC> vsencoding_codec();
-std::shared_ptr<IntegerCODEC> fastpfor128_codec();
-std::shared_ptr<IntegerCODEC> fastpfor256_codec();
-std::shared_ptr<IntegerCODEC> simdfastpfor128_codec();
-std::shared_ptr<IntegerCODEC> simdfastpfor256_codec();
-std::shared_ptr<IntegerCODEC> simplepfor_codec();
-std::shared_ptr<IntegerCODEC> simdsimplepfor_codec();
-std::shared_ptr<IntegerCODEC> pfor_codec();
-std::shared_ptr<IntegerCODEC> simdpfor_codec();
-std::shared_ptr<IntegerCODEC> pfor2008_codec();
-std::shared_ptr<IntegerCODEC> simdnewpfor_codec();
-std::shared_ptr<IntegerCODEC> newpfor_codec();
-std::shared_ptr<IntegerCODEC> optpfor_codec();
-std::shared_ptr<IntegerCODEC> simdoptpfor_codec();
-std::shared_ptr<IntegerCODEC> varint_codec();
-std::shared_ptr<IntegerCODEC> vbyte_codec();
-std::shared_ptr<IntegerCODEC> maskedvbyte_codec();
-std::shared_ptr<IntegerCODEC> streamvbyte_codec();
-std::shared_ptr<IntegerCODEC> varintgb_codec();
-std::shared_ptr<IntegerCODEC> simple16_codec();
-std::shared_ptr<IntegerCODEC> simple9_codec();
-std::shared_ptr<IntegerCODEC> simple9_rle_codec();
-std::shared_ptr<IntegerCODEC> simple8b_codec();
-std::shared_ptr<IntegerCODEC> simple8b_rle_codec();
+std::unique_ptr<IntegerCODEC> fastbinarypacking8_codec();
+std::unique_ptr<IntegerCODEC> fastbinarypacking16_codec();
+std::unique_ptr<IntegerCODEC> fastbinarypacking32_codec();
+std::unique_ptr<IntegerCODEC> BP32_codec();
+std::unique_ptr<IntegerCODEC> vsencoding_codec();
+std::unique_ptr<IntegerCODEC> fastpfor128_codec();
+std::unique_ptr<IntegerCODEC> fastpfor256_codec();
+std::unique_ptr<IntegerCODEC> simdfastpfor128_codec();
+std::unique_ptr<IntegerCODEC> simdfastpfor256_codec();
+std::unique_ptr<IntegerCODEC> simplepfor_codec();
+std::unique_ptr<IntegerCODEC> simdsimplepfor_codec();
+std::unique_ptr<IntegerCODEC> pfor_codec();
+std::unique_ptr<IntegerCODEC> simdpfor_codec();
+std::unique_ptr<IntegerCODEC> pfor2008_codec();
+std::unique_ptr<IntegerCODEC> simdnewpfor_codec();
+std::unique_ptr<IntegerCODEC> newpfor_codec();
+std::unique_ptr<IntegerCODEC> optpfor_codec();
+std::unique_ptr<IntegerCODEC> simdoptpfor_codec();
+std::unique_ptr<IntegerCODEC> varint_codec();
+std::unique_ptr<IntegerCODEC> vbyte_codec();
+std::unique_ptr<IntegerCODEC> maskedvbyte_codec();
+std::unique_ptr<IntegerCODEC> streamvbyte_codec();
+std::unique_ptr<IntegerCODEC> varintgb_codec();
+std::unique_ptr<IntegerCODEC> simple16_codec();
+std::unique_ptr<IntegerCODEC> simple9_codec();
+std::unique_ptr<IntegerCODEC> simple9_rle_codec();
+std::unique_ptr<IntegerCODEC> simple8b_codec();
+std::unique_ptr<IntegerCODEC> simple8b_rle_codec();
 #ifdef VARINTG8IU_H__
-std::shared_ptr<IntegerCODEC> varintg8iu_codec();
+std::unique_ptr<IntegerCODEC> varintg8iu_codec();
 #endif
 #ifdef USESNAPPY
-std::shared_ptr<IntegerCODEC> snappy_codec();
+std::unique_ptr<IntegerCODEC> snappy_codec();
 #endif
-std::shared_ptr<IntegerCODEC> simdbinarypacking_codec();
-std::shared_ptr<IntegerCODEC> simdgroupsimple_codec();
-std::shared_ptr<IntegerCODEC> simdgroupsimple_ringbuf_codec();
-std::shared_ptr<IntegerCODEC> copy_codec();
+std::unique_ptr<IntegerCODEC> simdbinarypacking_codec();
+std::unique_ptr<IntegerCODEC> simdgroupsimple_codec();
+std::unique_ptr<IntegerCODEC> simdgroupsimple_ringbuf_codec();
+std::unique_ptr<IntegerCODEC> copy_codec();
 
 } // namespace FastPForLib
 

--- a/src/codecfactory.cpp
+++ b/src/codecfactory.cpp
@@ -58,153 +58,153 @@ std::shared_ptr<IntegerCODEC> &CODECFactory::getFromName(std::string name) {
   return scodecmap[name];
 }
 
-std::shared_ptr<IntegerCODEC> fastbinarypacking8_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<FastBinaryPacking<8>, VariableByte>());
+std::unique_ptr<IntegerCODEC> fastbinarypacking8_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<FastBinaryPacking<8>, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> fastbinarypacking16_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<FastBinaryPacking<16>, VariableByte>());
+std::unique_ptr<IntegerCODEC> fastbinarypacking16_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<FastBinaryPacking<16>, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> fastbinarypacking32_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<FastBinaryPacking<32>, VariableByte>());
+std::unique_ptr<IntegerCODEC> fastbinarypacking32_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<FastBinaryPacking<32>, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> BP32_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<BP32, VariableByte>());
+std::unique_ptr<IntegerCODEC> BP32_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<BP32, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> vsencoding_codec() {
-  return std::shared_ptr<IntegerCODEC>(new vsencoding::VSEncodingBlocks(1U << 16));
+std::unique_ptr<IntegerCODEC> vsencoding_codec() {
+  return std::unique_ptr<IntegerCODEC>(new vsencoding::VSEncodingBlocks(1U << 16));
 }
-std::shared_ptr<IntegerCODEC> fastpfor128_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<FastPFor<4>, VariableByte>());
+std::unique_ptr<IntegerCODEC> fastpfor128_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<FastPFor<4>, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> fastpfor256_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<FastPFor<8>, VariableByte>());
+std::unique_ptr<IntegerCODEC> fastpfor256_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<FastPFor<8>, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> simdfastpfor128_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<SIMDFastPFor<4>, VariableByte>());
+std::unique_ptr<IntegerCODEC> simdfastpfor128_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<SIMDFastPFor<4>, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> simdfastpfor256_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<SIMDFastPFor<8>, VariableByte>());
+std::unique_ptr<IntegerCODEC> simdfastpfor256_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<SIMDFastPFor<8>, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> simplepfor_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<SimplePFor<>, VariableByte>());
+std::unique_ptr<IntegerCODEC> simplepfor_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<SimplePFor<>, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> simdsimplepfor_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<SIMDSimplePFor<>, VariableByte>());
+std::unique_ptr<IntegerCODEC> simdsimplepfor_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<SIMDSimplePFor<>, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> pfor_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<PFor, VariableByte>());
+std::unique_ptr<IntegerCODEC> pfor_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<PFor, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> simdpfor_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<SIMDPFor, VariableByte>());
+std::unique_ptr<IntegerCODEC> simdpfor_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<SIMDPFor, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> pfor2008_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<PFor2008, VariableByte>());
+std::unique_ptr<IntegerCODEC> pfor2008_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<PFor2008, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> simdnewpfor_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<SIMDNewPFor<4, Simple16<false>>, VariableByte>());
+std::unique_ptr<IntegerCODEC> simdnewpfor_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<SIMDNewPFor<4, Simple16<false>>, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> newpfor_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<NewPFor<4, Simple16<false>>, VariableByte>());
+std::unique_ptr<IntegerCODEC> newpfor_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<NewPFor<4, Simple16<false>>, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> optpfor_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<OPTPFor<4, Simple16<false>>, VariableByte>());
+std::unique_ptr<IntegerCODEC> optpfor_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<OPTPFor<4, Simple16<false>>, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> simdoptpfor_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<SIMDOPTPFor<4, Simple16<false>>, VariableByte>());
+std::unique_ptr<IntegerCODEC> simdoptpfor_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<SIMDOPTPFor<4, Simple16<false>>, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> varint_codec() {
-  return std::shared_ptr<IntegerCODEC>(new VariableByte());
+std::unique_ptr<IntegerCODEC> varint_codec() {
+  return std::unique_ptr<IntegerCODEC>(new VariableByte());
 }
-std::shared_ptr<IntegerCODEC> vbyte_codec() {
-  return std::shared_ptr<IntegerCODEC>(new VByte());
+std::unique_ptr<IntegerCODEC> vbyte_codec() {
+  return std::unique_ptr<IntegerCODEC>(new VByte());
 }
-std::shared_ptr<IntegerCODEC> maskedvbyte_codec() {
-  return std::shared_ptr<IntegerCODEC>(new MaskedVByte());
+std::unique_ptr<IntegerCODEC> maskedvbyte_codec() {
+  return std::unique_ptr<IntegerCODEC>(new MaskedVByte());
 }
-std::shared_ptr<IntegerCODEC> streamvbyte_codec() {
-  return std::shared_ptr<IntegerCODEC>(new StreamVByte());
+std::unique_ptr<IntegerCODEC> streamvbyte_codec() {
+  return std::unique_ptr<IntegerCODEC>(new StreamVByte());
 }
-std::shared_ptr<IntegerCODEC> varintgb_codec() {
-  return std::shared_ptr<IntegerCODEC>(new VarIntGB<>());
+std::unique_ptr<IntegerCODEC> varintgb_codec() {
+  return std::unique_ptr<IntegerCODEC>(new VarIntGB<>());
 }
-std::shared_ptr<IntegerCODEC> simple16_codec() {
-  return std::shared_ptr<IntegerCODEC>(new Simple16<true>());
+std::unique_ptr<IntegerCODEC> simple16_codec() {
+  return std::unique_ptr<IntegerCODEC>(new Simple16<true>());
 }
-std::shared_ptr<IntegerCODEC> simple9_codec() {
-  return std::shared_ptr<IntegerCODEC>(new Simple9<true>());
+std::unique_ptr<IntegerCODEC> simple9_codec() {
+  return std::unique_ptr<IntegerCODEC>(new Simple9<true>());
 }
-std::shared_ptr<IntegerCODEC> simple9_rle_codec() {
-  return std::shared_ptr<IntegerCODEC>(new Simple9_RLE<true>());
+std::unique_ptr<IntegerCODEC> simple9_rle_codec() {
+  return std::unique_ptr<IntegerCODEC>(new Simple9_RLE<true>());
 }
-std::shared_ptr<IntegerCODEC> simple8b_codec() {
-  return std::shared_ptr<IntegerCODEC>(new Simple8b<true>());
+std::unique_ptr<IntegerCODEC> simple8b_codec() {
+  return std::unique_ptr<IntegerCODEC>(new Simple8b<true>());
 }
-std::shared_ptr<IntegerCODEC> simple8b_rle_codec() {
-  return std::shared_ptr<IntegerCODEC>(new Simple8b_RLE<true>());
+std::unique_ptr<IntegerCODEC> simple8b_rle_codec() {
+  return std::unique_ptr<IntegerCODEC>(new Simple8b_RLE<true>());
 }
 #ifdef VARINTG8IU_H__
-std::shared_ptr<IntegerCODEC> varintg8iu_codec() {
-  return std::shared_ptr<IntegerCODEC>(new VarIntG8IU());
+std::unique_ptr<IntegerCODEC> varintg8iu_codec() {
+  return std::unique_ptr<IntegerCODEC>(new VarIntG8IU());
 }
 #endif
 #ifdef USESNAPPY
-std::shared_ptr<IntegerCODEC> snappy_codec() {
-  return std::shared_ptr<IntegerCODEC>(new JustSnappy());
+std::unique_ptr<IntegerCODEC> snappy_codec() {
+  return std::unique_ptr<IntegerCODEC>(new JustSnappy());
 }
 #endif
-std::shared_ptr<IntegerCODEC> simdbinarypacking_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<SIMDBinaryPacking, VariableByte>());
+std::unique_ptr<IntegerCODEC> simdbinarypacking_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<SIMDBinaryPacking, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> simdgroupsimple_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<SIMDGroupSimple<false, false>, VariableByte>());
+std::unique_ptr<IntegerCODEC> simdgroupsimple_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<SIMDGroupSimple<false, false>, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> simdgroupsimple_ringbuf_codec() {
-  return std::shared_ptr<IntegerCODEC>(new CompositeCodec<SIMDGroupSimple<true, true>, VariableByte>());
+std::unique_ptr<IntegerCODEC> simdgroupsimple_ringbuf_codec() {
+  return std::unique_ptr<IntegerCODEC>(new CompositeCodec<SIMDGroupSimple<true, true>, VariableByte>());
 }
-std::shared_ptr<IntegerCODEC> copy_codec() {
-  return std::shared_ptr<IntegerCODEC>(new JustCopy());
+std::unique_ptr<IntegerCODEC> copy_codec() {
+  return std::unique_ptr<IntegerCODEC>(new JustCopy());
 }
 
 static CodecMap initializefactory() {
   CodecMap map;
-  map["fastbinarypacking8"] = fastbinarypacking8_codec();
-  map["fastbinarypacking16"] = fastbinarypacking16_codec();
-  map["fastbinarypacking32"] = fastbinarypacking32_codec();
-  map["BP32"] = BP32_codec();
-  map["vsencoding"] = vsencoding_codec();
-  map["fastpfor128"] = fastpfor128_codec();
-  map["fastpfor256"] = fastpfor256_codec();
-  map["simdfastpfor128"] = simdfastpfor128_codec();
-  map["simdfastpfor256"] = simdfastpfor256_codec();
-  map["simplepfor"] = simplepfor_codec();
-  map["simdsimplepfor"] = simdsimplepfor_codec();
-  map["pfor"] = pfor_codec();
-  map["simdpfor"] = simdpfor_codec();
-  map["pfor2008"] = pfor2008_codec();
-  map["simdnewpfor"] = simdnewpfor_codec();
-  map["newpfor"] = newpfor_codec();
-  map["optpfor"] = optpfor_codec();
-  map["simdoptpfor"] = simdoptpfor_codec();
-  map["varint"] = varint_codec();
-  map["vbyte"] = vbyte_codec();
-  map["maskedvbyte"] = maskedvbyte_codec();
-  map["streamvbyte"] = streamvbyte_codec();
-  map["varintgb"] = varintgb_codec();
-  map["simple16"] = simple16_codec();
-  map["simple9"] = simple9_codec();
-  map["simple9_rle"] = simple9_rle_codec();
-  map["simple8b"] = simple8b_codec();
-  map["simple8b_rle"] = simple8b_rle_codec();
+  map["fastbinarypacking8"] = std::move(fastbinarypacking8_codec());
+  map["fastbinarypacking16"] = std::move(fastbinarypacking16_codec());
+  map["fastbinarypacking32"] = std::move(fastbinarypacking32_codec());
+  map["BP32"] = std::move(BP32_codec());
+  map["vsencoding"] = std::move(vsencoding_codec());
+  map["fastpfor128"] = std::move(fastpfor128_codec());
+  map["fastpfor256"] = std::move(fastpfor256_codec());
+  map["simdfastpfor128"] = std::move(simdfastpfor128_codec());
+  map["simdfastpfor256"] = std::move(simdfastpfor256_codec());
+  map["simplepfor"] = std::move(simplepfor_codec());
+  map["simdsimplepfor"] = std::move(simdsimplepfor_codec());
+  map["pfor"] = std::move(pfor_codec());
+  map["simdpfor"] = std::move(simdpfor_codec());
+  map["pfor2008"] = std::move(pfor2008_codec());
+  map["simdnewpfor"] = std::move(simdnewpfor_codec());
+  map["newpfor"] = std::move(newpfor_codec());
+  map["optpfor"] = std::move(optpfor_codec());
+  map["simdoptpfor"] = std::move(simdoptpfor_codec());
+  map["varint"] = std::move(varint_codec());
+  map["vbyte"] = std::move(vbyte_codec());
+  map["maskedvbyte"] = std::move(maskedvbyte_codec());
+  map["streamvbyte"] = std::move(streamvbyte_codec());
+  map["varintgb"] = std::move(varintgb_codec());
+  map["simple16"] = std::move(simple16_codec());
+  map["simple9"] = std::move(simple9_codec());
+  map["simple9_rle"] = std::move(simple9_rle_codec());
+  map["simple8b"] = std::move(simple8b_codec());
+  map["simple8b_rle"] = std::move(simple8b_rle_codec());
 #ifdef VARINTG8IU_H__
-  map["varintg8iu"] = varintg8iu_codec();
+  map["varintg8iu"] = std::move(varintg8iu_codec());
 #endif
 #ifdef USESNAPPY
-  map["snappy"] = snappy_codec();
+  map["snappy"] = std::move(snappy_codec());
 #endif
-  map["simdbinarypacking"] = simdbinarypacking_codec();
-  map["simdgroupsimple"] = simdgroupsimple_codec();
-  map["simdgroupsimple_ringbuf"] = simdgroupsimple_ringbuf_codec();
-  map["copy"] = copy_codec();
+  map["simdbinarypacking"] = std::move(simdbinarypacking_codec());
+  map["simdgroupsimple"] = std::move(simdgroupsimple_codec());
+  map["simdgroupsimple_ringbuf"] = std::move(simdgroupsimple_ringbuf_codec());
+  map["copy"] = std::move(copy_codec());
   return map;
 }
 


### PR DESCRIPTION
TIL: Turns out unique_ptr is more efficient as it does not need to have thread-safe ref-counting - so faster and smaller.