### PR TITLE
Detect NEON support more reliably in `environment.cmake`

### DIFF
--- a/cmake_modules/environment.cmake
+++ b/cmake_modules/environment.cmake
@@ -1,10 +1,27 @@
-include(CheckCXXCompilerFlag)
+include(CheckCSourceCompiles)
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "arm" OR CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set(SUPPORT_NEON ON)
-endif ()
+# Check if NEON is supported by compiling a test program
+check_c_source_compiles("
+    #include <arm_neon.h>
+    int main() {
+        float32x4_t a = vdupq_n_f32(0.0f);
+        return 0;
+    }
+" SUPPORT_NEON)
 
-# Check if the Visual Studio build is targeting ARM
-if (CMAKE_GENERATOR_PLATFORM MATCHES "ARM64" OR CMAKE_GENERATOR_PLATFORM MATCHES "ARM")
-    set(SUPPORT_NEON ON)
-endif ()
+# Alternatively, check for ARM architecture and NEON macros if the above fails
+if(NOT SUPPORT_NEON)
+    check_c_source_compiles("
+        #if defined(__ARM_NEON__) || (defined(__ARM_NEON) && defined(__aarch64__))
+        int main() { return 0; }
+        #else
+        #error NEON not available
+        #endif
+    " SUPPORT_NEON)
+endif()
+
+if(SUPPORT_NEON)
+    message(STATUS "NEON support enabled")
+else()
+    message(STATUS "NEON not supported")
+endif()


### PR DESCRIPTION
We are building for iOS and `CMAKE_GENERATOR_PLATFORM` is an empty string. So we ran into an issue that `SUPPORT_NEON` was not set correctly. The [CMake documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_PROCESSOR.html) also mentions:

> In many cases, this will correspond to the target architecture for the build, but this is not guaranteed. 

This is the solution DeepSeek came up with to more reliably detect NEON support. It looks legit? Seems to work as well.